### PR TITLE
fix file path for writing using Path.Combine instead of concatenation

### DIFF
--- a/ReadingTree/CSVReaderWriter.cs
+++ b/ReadingTree/CSVReaderWriter.cs
@@ -26,7 +26,7 @@ namespace ReadingTree
         }
 
         public static string workingDirectory = Path.GetDirectoryName((new System.Uri(Assembly.GetExecutingAssembly().CodeBase)).AbsolutePath);
-        public static string masterFP = workingDirectory + "\\all_levels.csv";
+        public static string masterFP = Path.Combine(workingDirectory,"all_levels.csv");
 
         // Read a row from the file
         public bool ReadRow(CsvRow row)
@@ -74,9 +74,9 @@ namespace ReadingTree
     // Class to write to a csv file
     public class CsvWriter : StreamWriter
     {
-        public static string workingDirectory = Directory.GetParent(Directory.GetCurrentDirectory()).Parent.FullName;
-        public static string masterFP = workingDirectory + "\\resources\\all_levels.csv";
-        public static string tempFP = workingDirectory + "\\resources\\tempFP.csv";
+        public static string workingDirectory = Path.GetDirectoryName((new System.Uri(Assembly.GetExecutingAssembly().CodeBase)).AbsolutePath);
+        public static string masterFP = Path.Combine(workingDirectory, "all_levels.csv");
+        public static string tempFP = Path.Combine(workingDirectory, "tempFP.csv");
         public CsvWriter(string file) : base(file)
         {
         }


### PR DESCRIPTION
Fixed file path errors when running from C:\
Updated write file path to match read file path